### PR TITLE
chore: bump smime-email to 1.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smime-email"
-version = "1.0.4"
+version = "1.0.5"
 description = "A Python library to generate a signed email"
 authors = [{ name = "Siemens" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "smime-email"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Changes

To release https://github.com/siemens/python-smime-email/pull/22 for [CVE-2026-39892](https://redirect.github.com/pyca/cryptography/security/advisories/GHSA-p423-j2cm-9vmq)

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

* [x] Documentation in the README
* [ ] Unit tests
