### PR TITLE
chore: bump smime-email to 1.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smime-email"
-version = "1.0.5"
+version = "1.0.6"
 description = "A Python library to generate a signed email"
 authors = [{ name = "Siemens" }]
 requires-python = ">=3.10, <4"

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "smime-email"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Changes

To release https://github.com/siemens/python-smime-email/pull/25 that addresses [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176)

### Documentation and testing

Please consider whether this PR needs documentation and tests. **This is not required**, but highly appreciated:

* [ ] Documentation in the README
* [ ] Unit tests
